### PR TITLE
Star indexes

### DIFF
--- a/api.py
+++ b/api.py
@@ -35,7 +35,8 @@ config["debug"] = str(os.getenv("DEBUG", config.get("debug", False))).lower() in
 
 ES = Elasticsearch(config["eshosts"], **config["esopts"])
 
-Collection = list_to_enum("Collection", config["indexes"])
+
+Collection = list_to_enum("Collection", config["indexes"]+["*"]) ##Simple way to expose a search interface over all indexes
 TermField = list_to_enum("TermField", config["termfields"])
 TermAggr = list_to_enum("TermAggr", config["termaggrs"])
 


### PR DESCRIPTION
Simplest way to add a search interface across all indexes- 
Might be preferable to pull the ELASTICSEARCH_INDEX_NAME_PREFIX from the environment (if it exists) and add "mediacloud_search_text_*" instead of just "*", but not sure the right order-of-operations for that. 