### PR TITLE
change query fto field name from field.keyword and typo fix

### DIFF
--- a/api.py
+++ b/api.py
@@ -187,7 +187,7 @@ def cs_terms_query(q: str, field: str = "article_title", aggr: str = "top"):
     aggr_map = {
         "top": {
             "terms": {
-                "field": f"{field}.keyword",
+                "field": f"{field}",
                 "size": resct,
                 "min_doc_count": 10,
                 "shard_min_doc_count": 5
@@ -195,7 +195,7 @@ def cs_terms_query(q: str, field: str = "article_title", aggr: str = "top"):
         },
         "significant": {
             "significant_terms": {
-                "field": f"{field}.keyword",
+                "field": f"{field}",
                 "size": resct,
                 "min_doc_count": 10,
                 "shard_min_doc_count": 5
@@ -203,7 +203,7 @@ def cs_terms_query(q: str, field: str = "article_title", aggr: str = "top"):
         },
         "rare": {
             "rare_terms": {
-                "field": f"{field}.keyword",
+                "field": f"{field}",
                 "exclude": "[0-9].*"
             }
         }

--- a/api.py
+++ b/api.py
@@ -187,7 +187,7 @@ def cs_terms_query(q: str, field: str = "article_title", aggr: str = "top"):
     aggr_map = {
         "top": {
             "terms": {
-                "field": f"{field}",
+                "field": field,
                 "size": resct,
                 "min_doc_count": 10,
                 "shard_min_doc_count": 5
@@ -195,7 +195,7 @@ def cs_terms_query(q: str, field: str = "article_title", aggr: str = "top"):
         },
         "significant": {
             "significant_terms": {
-                "field": f"{field}",
+                "field": field,
                 "size": resct,
                 "min_doc_count": 10,
                 "shard_min_doc_count": 5
@@ -203,7 +203,7 @@ def cs_terms_query(q: str, field: str = "article_title", aggr: str = "top"):
         },
         "rare": {
             "rare_terms": {
-                "field": f"{field}",
+                "field": field,
                 "exclude": "[0-9].*"
             }
         }

--- a/ui.py
+++ b/ui.py
@@ -110,7 +110,7 @@ for i, (k, v) in enumerate(fmap.items()):
         tbs[0].altair_chart(c, use_container_width=True)
         tbs[1].write(ov[v])
 
-for fld in ["article_title", "text_context"]:
+for fld in ["article_title", "text_content"]:
     cols = st.columns(3)
     for i, aggr in enumerate(["top", "significant", "rare"]):
         with cols[i]:


### PR DESCRIPTION
Since we're introducing `fielddata:true` in the ES schema, we should do the aggregation queries against the fieldname and not `field.keyword` 