### PR TITLE
Start of updates to docker-compose.yml for independent deployment of news-search-api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,36 @@
+# to deploy: docker compose up --detach ??
+
+x-service-settings: &service-settings
+  image: mcsystems/news-search-api:v1.0.0b2
+
+x-environment-vars: &environment-vars
+  INDEXES: mediacloud_search_text_older,mediacloud_search_text_other,mediacloud_search_text_2021,mediacloud_search_text_2022,mediacloud_search_text_2023,mediacloud_search_text_2024
+  TZ: "GMT"
+
 services:
   api:
-    image: mcsystems/news-search-api
-    build: .
-    ports:
-      - 8000:8000
-    networks:
-      - story-indexer
-    volumes:
-      - .:/app
-
-  ui:
-    image: mcsystems/news-search-api
+    <<: *service-settings
     build: .
     environment:
-      APIURL: http://api:8000/v1
+      <<: *environment-vars
+      DESCRIPTION: "Description Here"
+      # ES config here only; ui should use API only:
+      ELASTICSEARCH_INDEX_NAME_PREFIX: mediacloud_search_text
+      ESHOSTS: http://ramos.angwin:9204,http://woodward.angwin:9200,http://bradley.angwin:9204
+      ESOPTS: '{"timeout": 60, "max_retries": 3}' # 'timeout' parameter is deprecated
+      TERMAGGRS: top,significant,rare
+      TERMFIELDS: article_title,text_content
     ports:
-      - 8001:8501
-    networks:
-      - story-indexer
-    volumes:
-      - .:/app
+      - 8000:8000
+
+  query:
+    <<: *service-settings
+    environment:
+      <<: *environment-vars
+      APIURL: http://api:8000/v1
+      TITLE: "Title Here"
+    ports:
+      - 8501:8501
     depends_on:
       - api
     command: streamlit run ui.py
-
-networks:
-  story-indexer:
-    name: story-indexer
-    external: true

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,20 +6,22 @@ Before you begin, ensure you have the following prerequisites in place:
 
 2. Docker Compose: Make sure you have Docker Compose installed, as it's essential for managing multi-container applications. You can install Docker Compose by following the instructions in the official [documentation](https://docs.docker.com/compose/install/).
 
-### Network Setup
+The Web Search API connects to the production Elasticsearch cluster running (outside docker) on ramos, woodward and bradley.
 
-The Web Search API should connect to the Elasticsearch cluster running from the `indexer`. 
-The `indexer` runs as a swarm cluster and therefore to expose the ES endpoint to the API, we need to deploy the Web Search API in the same overlay network
+### Building
 
-To create the network (if non exists)
-
-    `docker network create -d overlay --attachable story-indexer`
-
+text here
 
 ### Docker compose
 
-If relying on a shared network for the Search API and the `indexer`, ensure the `docker-compose.yml` is attached to th overlay network created above.
+To run the services
 
-To build & run the services
+    `docker compose up --detach`
 
-    `docker compose up --build`
+To stop:
+
+    `docker compose down`
+
+### Releasing
+
+text here


### PR DESCRIPTION
Start of an attempt to update news-search-api/docker-compose.yml to deploy JUST api and ui containers

No longer needs to be in story-indexer docker-compose.yml file because production ES servers are not docker containers, and it's useful to be able to deploy different versions of the software (in different stages of development/test) in different places.

This makes it possible to have a news-search-api deployment for the production mcweb (ie; on tarbell), another for staging-mcweb (on steinam), and others for developers.

See https://github.com/mediacloud/news-search-api/issues/27#issuecomment-1848798077