### PR TITLE
Fix indexed_date to return as datetime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install python dependencies
         run: |
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
       - name: Install fixtures
         run: |
           python -m test.create_fixtures

--- a/api.py
+++ b/api.py
@@ -297,7 +297,7 @@ def format_match(hit: dict, base: str, collection: str, expanded: bool = False):
         "article_title": src.get("article_title") or "[UNKNOWN]",
         "normalized_article_title": src.get("normalized_article_title") or "[UNKNOWN]",
         "publication_date": (src.get("publication_date") or "[UNKNOWN]")[:10],
-        "indexed_date": (src.get("indexed_date") or "[UNKNOWN]")[:10],
+        "indexed_date": (src.get("indexed_date") or "[UNKNOWN]"),
         "language": src.get("language") or "[UNKNOWN]",
         "full_langauge": src.get("full_language") or "[UNKNOWN]",
         "url": src.get("url") or "[UNKNOWN]",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+mediacloud-metadata>=0.11.1
+pytest==7.*
+httpx==0.25.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,4 @@ streamlit==1.29.*
 uvicorn[standard]
 wordcloud==1.9.*
 pyyaml==6.0.*
-pytest==7.*
-httpx==0.25.*
 sentry-sdk[fastapi]==1.*


### PR DESCRIPTION
This verifies that indexed_date is stored and retrieved as a datetime (fixing #46).