### PR TITLE
Add new paging tests, more detailed sort instructions

### DIFF
--- a/api.py
+++ b/api.py
@@ -282,7 +282,7 @@ def cs_paged_query(q: str, resume: Optional[str], expanded: Optional[bool], sort
     query.update({
         "size": _validate_page_size(page_size or config["maxpage"]),
         "track_total_hits": False,
-        "sort": [{final_sort_field: final_sort_order}]
+        "sort": {final_sort_field: {"order": final_sort_order, "format": "basic_date_time_no_millis"}},
     })
     if resume:
         # important to use `search_after` instead of 'from' for memory reasons related to paging through more

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -3,3 +3,4 @@ import os
 INDEX_NAME = "mediacloud_test"
 ELASTICSEARCH_URL = "http://localhost:9200"
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+NUMBER_OF_TEST_STORIES = 5103

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -83,6 +83,7 @@ class ApiTest(TestCase):
         # now page through to make sure it matches
         more_stories = True
         next_page_token = None
+        page_count = 0
         stories = []
         while more_stories:
             response = self._client.post(f'/v1/{INDEX_NAME}/search/result',
@@ -93,8 +94,10 @@ class ApiTest(TestCase):
             next_page_token = response.headers.get('x-resume-token')
             stories += results
             more_stories = next_page_token is not None
+            page_count += 1
         # not sure why all stories don't get imported, but account for it here
         assert len(stories) >= (total_expected_stories * 0.9)
+        assert page_count == (1 + int(total_expected_stories / 1000))
 
     def test_text_content_expanded(self):
         response = self._client.post(f'/v1/{INDEX_NAME}/search/result',

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -4,7 +4,7 @@ import datetime as dt
 from fastapi.testclient import TestClient
 
 import api
-from test import INDEX_NAME, ELASTICSEARCH_URL
+from test import INDEX_NAME, ELASTICSEARCH_URL, NUMBER_OF_TEST_STORIES
 # make sure to set these env vars before importing the app so it runs against a test ES you've set up with
 # the `create_fixtures.py` script
 os.environ["INDEXES"] = INDEX_NAME
@@ -72,6 +72,30 @@ class ApiTest(TestCase):
         next_page_token = response.headers.get('x-resume-token')
         assert next_page_token is not None
 
+    def test_paging_all(self):
+        # get total count
+        response = self._client.post(f'/v1/{INDEX_NAME}/search/overview', json={"q": "*"}, timeout=TIMEOUT)
+        assert response.status_code == 200
+        results = response.json()
+        assert 'total' in results
+        assert results['total'] == NUMBER_OF_TEST_STORIES
+        total_expected_stories = results['total']
+        # now page through to make sure it matches
+        more_stories = True
+        next_page_token = None
+        stories = []
+        while more_stories:
+            response = self._client.post(f'/v1/{INDEX_NAME}/search/result',
+                                         json={"q": "*", "resume": next_page_token}, timeout=TIMEOUT)
+            assert response.status_code == 200
+            results = response.json()
+            assert len(results) > 0
+            next_page_token = response.headers.get('x-resume-token')
+            stories += results
+            more_stories = next_page_token is not None
+        # not sure why all stories don't get imported, but account for it here
+        assert len(stories) >= (total_expected_stories * 0.9)
+
     def test_text_content_expanded(self):
         response = self._client.post(f'/v1/{INDEX_NAME}/search/result',
                                      json={"q": "*", "expanded": 1}, timeout=TIMEOUT)
@@ -88,8 +112,8 @@ class ApiTest(TestCase):
                                      json={"q": "*"}, timeout=TIMEOUT)
         assert response.status_code == 200
         results = response.json()
-        tomorrow = dt.date.today() + dt.timedelta(days=1)
-        last_pub_date = tomorrow
+        future = dt.date(2050, 1, 1)
+        last_pub_date = future
         for story in results:
             assert 'text_content' not in story
             assert 'publication_date' in story
@@ -118,8 +142,8 @@ class ApiTest(TestCase):
                                      json={"q": "*", "sort_field": "publication_date"}, timeout=TIMEOUT)
         assert response.status_code == 200
         results = response.json()
-        tomorrow = dt.date.today() + dt.timedelta(days=1)
-        last_date = tomorrow
+        future = dt.date(2050, 1, 1)
+        last_date = future
         for story in results:
             assert 'text_content' not in story
             assert 'publication_date' in story
@@ -131,8 +155,8 @@ class ApiTest(TestCase):
                                      json={"q": "*", "sort_field": "indexed_date"}, timeout=TIMEOUT)
         assert response.status_code == 200
         results = response.json()
-        tomorrow = dt.datetime.today() + dt.timedelta(days=1)
-        last_date = tomorrow
+        future = dt.datetime(2050, 1, 1)
+        last_date = future
         for story in results:
             assert 'indexed_date' in story
             story_date = dt.datetime.fromisoformat(story['indexed_date'])

--- a/test/create_fixtures.py
+++ b/test/create_fixtures.py
@@ -1,14 +1,13 @@
 import logging
 import datetime as dt
 import copy
-import hashlib
 from random import randrange
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import ConflictError
 import mcmetadata.urls as urls
 import mcmetadata.titles as titles
 
-from test import INDEX_NAME, ELASTICSEARCH_URL
+from test import INDEX_NAME, ELASTICSEARCH_URL, NUMBER_OF_TEST_STORIES
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -59,7 +58,7 @@ base_fixture = {
 }
 
 imported_count = 0
-for idx in range(0, 2000):
+for idx in range(0, NUMBER_OF_TEST_STORIES):
     fixture = copy.copy(base_fixture)
     fixture['url'] += str(idx)
     fixture['original_url'] = fixture['url']
@@ -67,7 +66,7 @@ for idx in range(0, 2000):
     fixture['article_title'] += str(idx)
     fixture['normalized_article_title'] = titles.normalize_title(fixture['article_title'])
     fixture['text_content'] += str(idx)
-    fixture['publication_date'] = "2023-" + str(10+int(idx / 1000)) + "-" + str(1 + (idx % 29)).zfill(2)
+    fixture['publication_date'] = (dt.date(2023, 1, 1) + dt.timedelta(days=randrange(365))).isoformat()
     random_time_on_day = dt.datetime.fromisoformat(fixture['publication_date']) + dt.timedelta(minutes=randrange(1440))
     fixture['indexed_date'] = random_time_on_day.isoformat()
     unique_hash = urls.unique_url_hash(fixture['url'])


### PR DESCRIPTION
This inserts more randomized fixtures, and adds a new `test_paging_all` method that verifies that paging through all of them works. In addition, these changes add more detailed sorting instructions (just to be sure it is doing it right as [per docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html)).

The weird thing is that when I count stories and then page through them all, I don't get the _exact_ number back. This inserts 5103, and the total count returns that same value. However when I try to page through them all I only get 5081 results back (over 6 pages). That said, it is paging through _almost_ all the stories and not returning a 404 anywhere.