### PR TITLE
ensure `None` publication_dates don't break things

### DIFF
--- a/api.py
+++ b/api.py
@@ -310,20 +310,20 @@ def cs_paged_query(
 def format_match(hit: dict, base: str, collection: str, expanded: bool = False):
     src = hit["_source"]
     res = {
-        "article_title": src.get("article_title") or "[UNKNOWN]",
-        "normalized_article_title": src.get("normalized_article_title") or "[UNKNOWN]",
-        "publication_date": (src.get("publication_date") or "[UNKNOWN]")[:10],
-        "indexed_date": (src.get("indexed_date") or "[UNKNOWN]"),
-        "language": src.get("language") or "[UNKNOWN]",
-        "full_langauge": src.get("full_language") or "[UNKNOWN]",
-        "url": src.get("url") or "[UNKNOWN]",
-        "normalized_url": src.get("normalized_url") or "[UNKNOWN]",
-        "original_url": src.get("original_url") or "[UNKNOWN]",
-        "canonical_domain": src.get("canonical_domain") or "[UNKNOWN]",
+        "article_title": src.get("article_title"),
+        "normalized_article_title": src.get("normalized_article_title"),
+        "publication_date": src.get("publication_date")[:10] if src.get("publication_date") else None,
+        "indexed_date": src.get("indexed_date"),
+        "language": src.get("language"),
+        "full_langauge": src.get("full_language"),
+        "url": src.get("url"),
+        "normalized_url": src.get("normalized_url"),
+        "original_url": src.get("original_url"),
+        "canonical_domain": src.get("canonical_domain"),
     }
     if expanded:
-        res["text_content"] = src.get("text_content", "")
-        res["text_extraction"] = src.get("text_extraction", "")
+        res["text_content"] = src.get("text_content")
+        res["text_extraction"] = src.get("text_extraction")
     return res
 
 

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -316,3 +316,15 @@ class ApiTest(TestCase):
         assert len(url_list_take1) == len(url_list_take2)
         for idx in range(0, len(url_list_take2)):
             assert url_list_take1[idx] == url_list_take2[idx]
+
+    def test_no_pub_date(self):
+        response = self._client.post(
+            f"/v1/{INDEX_NAME}/search/overview",
+            json={"q": '"no publication date"'},
+            timeout=TIMEOUT,
+        )
+        results = response.json()
+        assert response.status_code == 200
+        assert results['total'] == 1 + int(NUMBER_OF_TEST_STORIES / 1000)
+        for s in results['matches']:
+            assert s['publication_date'] == '[UNKNOWN]'

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -327,4 +327,4 @@ class ApiTest(TestCase):
         assert response.status_code == 200
         assert results['total'] == 1 + int(NUMBER_OF_TEST_STORIES / 1000)
         for s in results['matches']:
-            assert s['publication_date'] == '[UNKNOWN]'
+            assert s['publication_date'] is None

--- a/test/create_fixtures.py
+++ b/test/create_fixtures.py
@@ -68,16 +68,19 @@ for idx in range(0, NUMBER_OF_TEST_STORIES):
     fixture["original_url"] = fixture["url"]
     fixture["normalized_url"] = urls.normalize_url(fixture["url"])  # type: ignore [assignment]
     fixture["article_title"] += str(idx)
+    fixture["text_content"] += str(idx)
+    pub_date = dt.date(2023, 1, 1) + dt.timedelta(days=randrange(365))
+    if (idx % 1000) != 0:
+        fixture["publication_date"] = pub_date.isoformat()
+    else:  # make sure some have no publication date, and mark them for easy searching
+        fixture["publication_date"] = None
+        fixture["article_title"] += " (no publication date)"
+        fixture["text_content"] += " (no publication date)"
     fixture["normalized_article_title"] = titles.normalize_title(
         fixture["article_title"]
     )
-    fixture["text_content"] += str(idx)
-    fixture["publication_date"] = (
-        dt.date(2023, 1, 1) + dt.timedelta(days=randrange(365))
-    ).isoformat()
-    random_time_on_day = dt.datetime.fromisoformat(
-        fixture["publication_date"]
-    ) + dt.timedelta(minutes=randrange(1440))
+    random_time_on_day = (dt.datetime(pub_date.year, pub_date.month, pub_date.day) +
+                          dt.timedelta(minutes=randrange(1440)))
     fixture["indexed_date"] = random_time_on_day.isoformat()
     unique_hash = urls.unique_url_hash(fixture["url"])
     try:


### PR DESCRIPTION
Based on https://github.com/mediacloud/story-indexer/issues/186, we will soon be importing stories that have `None` as the publication_date value. This change adds some stories like that to the test fixtures, and verifies that they can be searched (by content).

This also changes _all_ results so that `None` is returned for any field that doesn't have a value, instead of the string "[UKNOWN]" (which seems pretty hard to use as an API client). I don't see this string used anywhere in the API client, so I feel comfortable changing this default to something that I think makes more sense.