### PR TITLE
Tweaks to get failing test to pass, and update requirements to latest for release prep

### DIFF
--- a/api.py
+++ b/api.py
@@ -628,5 +628,5 @@ if __name__ == "__main__":
     import uvicorn
 
     uvicorn.run(
-        "api:app", host="0.0.0.0", reload=True, root_path=os.getenv("ROOT_PATH", "/")
+        "api:app", host="0.0.0.0", reload=True, root_path=os.getenv("ROOT_PATH", "")
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,4 +16,4 @@ sentry-sdk[fastapi]==1.*
 mediacloud-metadata>=0.11.1
 pre-commit==3.6.*
 pytest==7.*
-httpx==0.25.*
+httpx==0.26.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 altair==5.2.*
-elasticsearch==8.8.*
-fastapi==0.104.*
+elasticsearch==8.12.*
+fastapi==0.109.*
 matplotlib==3.8.*
-pandas==2.1.*
+pandas==2.2.*
 pydantic==2.5.*
 requests
-streamlit==1.29.*
+streamlit==1.30.*
 uvicorn[standard]
 wordcloud==1.9.*
 pyyaml==6.0.*

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -107,6 +107,8 @@ class ApiTest(TestCase):
                 json={"q": query, "page_size": page_size, "resume": next_page_token},
                 timeout=TIMEOUT,
             )
+            if response.status_code == 404:  # no more results
+                break
             assert response.status_code == 200
             results = response.json()
             assert len(results) > 0


### PR DESCRIPTION
Very strange, but the "/" default path was leading to the whole API breaking when run from command line. Unit tests ran fine though. This gets all unit tests, and integration test in mediacloud-news-client passing (locally) again.