### PR TITLE
fix: change query to fetch article by ID

### DIFF
--- a/api.py
+++ b/api.py
@@ -615,7 +615,7 @@ def get_article(
     """
     Fetch an individual article record by ID.
     """
-    source = cs_basic_query(id, expanded=True)
+    source = {"includes": cs_basic_query(id, expanded=True)["_source"]}
     query = {"match": {"_id": id}}
 
     try:

--- a/api.py
+++ b/api.py
@@ -634,10 +634,17 @@ def get_article(
 
     try:
         res = ES.search(index=collection.name, source=source, query=query)
-        hit = res["hits"]["hits"][0]
+        hits = res["hits"]["hits"]
+        if len(hits) > 0:
+            hit = hits[0]
+        else:
+            raise HTTPException(
+                status_code=404, detail=f"An article with ID {id} not found!"
+            )
     except TransportError as e:
         raise HTTPException(
-            status_code=404, detail=f"An article with ID {id} not found!"
+            status_code=500,
+            detail=f"An error occured when searching for article with ID {id}",
         ) from e
     base = proxy_base_url(req)
     return format_match(hit, base, collection.name, True)  # type: ignore[arg-type]

--- a/api.py
+++ b/api.py
@@ -615,8 +615,8 @@ def get_article(
     """
     Fetch an individual article record by ID.
     """
-    query = {
-        "_source": [
+    source = {
+        "includes": [
             "article_title",
             "normalized_article_title",
             "publication_date",
@@ -628,15 +628,12 @@ def get_article(
             "normalized_url",
             "original_url",
             "text_content",
-        ],
-        "query": {
-            "match": {
-                "_id": id
-            }
-        },
+        ]
     }
+    query = {"match": {"_id": id}}
+
     try:
-        res = ES.search(index=collection.name, body=query)
+        res = ES.search(index=collection.name, source=source, query=query)
         hit = res["hits"]["hits"][0]
     except TransportError as e:
         raise HTTPException(

--- a/api.py
+++ b/api.py
@@ -616,11 +616,23 @@ def get_article(
     Fetch an individual article record by ID.
     """
     query = {
+        "_source": [
+            "article_title",
+            "normalized_article_title",
+            "publication_date",
+            "indexed_date",
+            "language",
+            "full_language",
+            "canonical_domain",
+            "url",
+            "normalized_url",
+            "original_url",
+        ],
         "query": {
-            "term": {
-            "_id": id
+            "match": {
+                "_id": id
             }
-        }
+        },
     }
     try:
         hit = ES.search(index=collection.name, body=query)

--- a/api.py
+++ b/api.py
@@ -627,6 +627,7 @@ def get_article(
             "url",
             "normalized_url",
             "original_url",
+            "text_content",
         ],
         "query": {
             "match": {

--- a/api.py
+++ b/api.py
@@ -615,9 +615,15 @@ def get_article(
     """
     Fetch an individual article record by ID.
     """
-
+    query = {
+        "query": {
+            "term": {
+            "_id": id
+            }
+        }
+    }
     try:
-        hit = ES.get(index=collection.name, id=id)
+        hit = ES.search(index=collection.name, body=query)
     except TransportError as e:
         raise HTTPException(
             status_code=404, detail=f"An article with ID {id} not found!"

--- a/api.py
+++ b/api.py
@@ -635,7 +635,8 @@ def get_article(
         },
     }
     try:
-        hit = ES.search(index=collection.name, body=query)
+        res = ES.search(index=collection.name, body=query)
+        hit = res["hits"]["hits"][0]
     except TransportError as e:
         raise HTTPException(
             status_code=404, detail=f"An article with ID {id} not found!"


### PR DESCRIPTION
This PR is a quick fix on searching an article by `id`. Since we're switching to ILM, we expect to conduct search on the index alias that maps to multiple indices. The [GET ap](https://elasticsearch-py.readthedocs.io/en/v8.12.0/api/elasticsearch.html#elasticsearch.Elasticsearch.get)i assumes searching a single index, hence the error posted on slack.

`{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"alias [mc_search] has more than one index associated with it `
