### PR TITLE
fix ES index name prefix

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -158,7 +158,7 @@ DOCKER_COMPOSE_FILE="docker-compose.yml"
 
 export INDEXES="mc_search"
 export ESOPTS='{"timeout": 60, "max_retries": 3}' # 'timeout' parameter is deprecated
-export ELASTICSEARCH_INDEX_NAME_PREFIX="mc_search-*"
+export ELASTICSEARCH_INDEX_NAME_PREFIX="mc_search"
 export TERMFIELDS="article_title,text_content"
 export TERMAGGRS="top,significant,rare"
 export API_PORT


### PR DESCRIPTION
Bugfix since the `ELASTICSEARCH_INDEX_NAME_PREFIX="mc_search-*"` exposed an index with the pattern `mc-search-*-*` that throws errors on search , not a valid index pattern