### PR TITLE
Extract ES interface from FastAPI routing definition 

### DIFF
--- a/api.py
+++ b/api.py
@@ -264,7 +264,8 @@ def search_result_via_query_params(
         sort_order,
         page_size,
     )
-    resp.headers["x-resume-token"] = resume_key
+    if resume_key:
+        resp.headers["x-resume-token"] = resume_key
     return result
 
 
@@ -284,7 +285,8 @@ def search_result_via_payload(
         payload.sort_order,
         payload.page_size,
     )
-    resp.headers["x-resume-token"] = resume_key
+    if resume_key:
+        resp.headers["x-resume-token"] = resume_key
     return result
 
 

--- a/api.py
+++ b/api.py
@@ -17,34 +17,21 @@ from pydantic import BaseModel
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 
+from queries import EsClientWrapper
 from utils import (
     assert_elasticsearch_connection,
     env_to_dict,
+    env_to_float,
     env_to_list,
     load_config,
     logger,
 )
 
-def getenv_float(name: str, defval: float | None) -> float | None:
-    """
-    fetch environment variable with name `name`
-    if not set, return defval
-    if set to empty string, return None
-    else interpret as floating point number
-    """
-    val = os.getenv(name)
-    if val is None:
-        return defval
-    if val == "":
-        return None
-    return float(val)
-
-
 if os.getenv("SENTRY_DSN"):
     sentry_sdk.init(
         dsn=os.getenv("SENTRY_DSN"),
-        traces_sample_rate=getenv_float("TRACING_SAMPLE_RATE", 1.0),
-        profiles_sample_rate=getenv_float("PROFILES_SAMPLE_RATE", 1.0),
+        traces_sample_rate=env_to_float("TRACING_SAMPLE_RATE", 1.0),
+        profiles_sample_rate=env_to_float("PROFILES_SAMPLE_RATE", 1.0),
         integrations=[
             StarletteIntegration(transaction_style="url"),
             FastApiIntegration(transaction_style="url"),
@@ -59,13 +46,10 @@ class ApiVersion(str, Enum):
 
 
 config = load_config()
-config["termfields"] = env_to_list("TERMFIELDS") or config.get("termfields", [])
-config["termaggrs"] = env_to_list("TERMAGGRS") or config.get("termaggrs", [])
 config["eshosts"] = env_to_list("ESHOSTS") or config.get(
     "eshosts", ["http://localhost:9200"]
 )
 config["esopts"] = env_to_dict("ESOPTS") or config.get("esopts", {})
-config["maxpage"] = int(os.getenv("MAXPAGE", config.get("maxpage", 1000)))
 config["title"] = os.getenv("TITLE", config.get("title", ""))
 config["description"] = os.getenv("DESCRIPTION", config.get("description", ""))
 config["debug"] = str(os.getenv("DEBUG", config.get("debug", False))).lower() in (
@@ -74,46 +58,11 @@ config["debug"] = str(os.getenv("DEBUG", config.get("debug", False))).lower() in
     "t",
 )
 
-ELASTICSEARCH_INDEX_NAME_PREFIX = os.getenv("ELASTICSEARCH_INDEX_NAME_PREFIX", "")
+ES = EsClientWrapper(config["eshosts"], **config["esopts"])
 
-ES = Elasticsearch(config["eshosts"], **config["esopts"])
-
-max_retries = 10
-retries = 0
-while not assert_elasticsearch_connection(ES):
-    retries += 1
-    if retries < max_retries:
-        time.sleep(5)
-        logger.info(f"Connection to elasticsearch failed {retries} times, retrying")
-    else:
-        raise RuntimeError(
-            f"Elasticsearch connection failed {max_retries} times, giving up."
-        )
-
-
-def get_allowed_collections():
-    # Only expose indexes with the correct prefix, and add a wildcard as well.
-
-    all_indexes = [
-        index
-        for index in ES.indices.get(index="*")
-        if index.startswith(ELASTICSEARCH_INDEX_NAME_PREFIX)
-    ]
-    for aliases in ES.indices.get_alias().values():
-        # returns: {"index_name":{"aliases":{"alias_name":{"is_write_index":bool}}}}
-        for alias in aliases["aliases"].keys():
-            if alias not in all_indexes:
-                all_indexes.append(alias)
-    all_indexes.append(f"{ELASTICSEARCH_INDEX_NAME_PREFIX}-*")
-
-    logger.info(f"Exposed indices: {all_indexes}")
-    return all_indexes
-
-
-# A little annoying- the list comprehension could be removed in py3.11 by using StrEnum, but this is backwards compatable.
-Collection = Enum("Collection", [f"{kv}:{kv}".split(":")[:2] for kv in get_allowed_collections()])  # type: ignore [misc]
-TermField = Enum("TermField", [f"{kv}:{kv}".split(":")[:2] for kv in config["termfields"]])  # type: ignore [misc]
-TermAggr = Enum("TermAggr", [f"{kv}:{kv}".split(":")[:2] for kv in config["termaggrs"]])  # type: ignore [misc]
+Collection = Enum("Collection", [f"{kv}:{kv}".split(":")[:2] for kv in ES.get_allowed_collections()])  # type: ignore [misc]
+TermField = Enum("TermField", [f"{kv}:{kv}".split(":")[:2] for kv in env_to_list("TERMFIELDS")])  # type: ignore [misc]
+TermAggr = Enum("TermAggr", [f"{kv}:{kv}".split(":")[:2] for kv in env_to_list("TERMFIELDS")])  # type: ignore [misc]
 
 
 tags = [
@@ -133,7 +82,6 @@ if config["debug"]:
             "description": "Debugging endpoints with raw data from the backend, not suitable to be enabled in production.",
         }
     )
-
 
 app = FastAPI(
     version=list(ApiVersion)[-1].value, docs_url=None, redoc_url=None, openapi_url=None
@@ -163,10 +111,6 @@ v1 = FastAPI(
 )
 
 
-VALID_SORT_ORDERS = ["asc", "desc"]
-VALID_SORT_FIELDS = ["publication_date", "indexed_date"]
-
-
 class Query(BaseModel):
     q: str
 
@@ -177,188 +121,6 @@ class PagedQuery(Query):
     sort_field: Optional[str] = None
     sort_order: Optional[str] = None
     page_size: Optional[int] = None
-
-
-def encode(strng: str):
-    return base64.b64encode(strng.encode(), b"-_").decode().replace("=", "~")
-
-
-def decode(strng: str):
-    return base64.b64decode(strng.replace("~", "=").encode(), b"-_").decode()
-
-
-def cs_basic_query(q: str, expanded: bool = False) -> Dict:
-    default: dict = {
-        "_source": [
-            "article_title",
-            "normalized_article_title",
-            "publication_date",
-            "indexed_date",
-            "language",
-            "full_language",
-            "canonical_domain",
-            "url",
-            "normalized_url",
-            "original_url",
-        ],
-        "query": {
-            "query_string": {
-                "default_field": "text_content",
-                "default_operator": "AND",
-                "query": q,
-            }
-        },
-    }
-    if expanded:
-        default["_source"].extend(["text_content", "text_extraction"])
-    return default
-
-
-def cs_overview_query(q: str):
-    query = cs_basic_query(q)
-    query.update(
-        {
-            "aggregations": {
-                "daily": {
-                    "date_histogram": {
-                        "field": "publication_date",
-                        "calendar_interval": "day",
-                        "min_doc_count": 1,
-                    }
-                },
-                "lang": {"terms": {"field": "language.keyword", "size": 100}},
-                "domain": {"terms": {"field": "canonical_domain", "size": 100}},
-                "tld": {"terms": {"field": "tld", "size": 100}},
-            },
-            "track_total_hits": True,
-        }
-    )
-
-    return query
-
-
-def cs_terms_query(q: str, field: TermField, aggr: TermAggr):
-    resct = 200
-    aggr_map = {
-        "top": {
-            "terms": {
-                "field": field.name,
-                "size": resct,
-                "min_doc_count": 10,
-                "shard_min_doc_count": 5,
-            }
-        },
-        "significant": {
-            "significant_terms": {
-                "field": field.name,
-                "size": resct,
-                "min_doc_count": 10,
-                "shard_min_doc_count": 5,
-            }
-        },
-        "rare": {"rare_terms": {"field": field.name, "exclude": "[0-9].*"}},
-    }
-    query = cs_basic_query(q)
-    query.update(
-        {
-            "track_total_hits": False,
-            "_source": False,
-            "aggregations": {
-                "sample": {
-                    "sampler": {"shard_size": 10 if aggr.name == "rare" else 500},
-                    "aggregations": {"topterms": aggr_map[aggr.name]},
-                }
-            },
-        }
-    )
-    return query
-
-
-def _validate_sort_order(sort_order: Optional[str]):
-    if sort_order and sort_order not in VALID_SORT_ORDERS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Invalid sort order (must be on of {', '.join(VALID_SORT_ORDERS)})",
-        )
-    return sort_order
-
-
-def _validate_sort_field(sort_field: Optional[str]):
-    if sort_field and sort_field not in VALID_SORT_FIELDS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Invalid sort field (must be on of {', '.join(VALID_SORT_FIELDS)})",
-        )
-    return sort_field
-
-
-def _validate_page_size(page_size: Optional[int]):
-    if page_size and page_size < 1:
-        raise HTTPException(
-            status_code=400, detail="Invalid page size (must be greater than 0)"
-        )
-    return page_size
-
-
-def cs_paged_query(
-    q: str,
-    resume: Union[str, None],
-    expanded: bool,
-    sort_field=Optional[str],
-    sort_order=Optional[str],
-    page_size=Optional[int],
-) -> Dict:
-    query = cs_basic_query(q, expanded)
-    final_sort_field = _validate_sort_field(sort_field or "publication_date")
-    final_sort_order = _validate_sort_order(sort_order or "desc")
-    query.update(
-        {
-            "size": _validate_page_size(page_size or config["maxpage"]),
-            "track_total_hits": False,
-            "sort": {
-                final_sort_field: {
-                    "order": final_sort_order,
-                    "format": "basic_date_time_no_millis",
-                }
-            },
-        }
-    )
-    if resume:
-        # important to use `search_after` instead of 'from' for memory reasons related to paging through more
-        # than 10k results
-        query["search_after"] = [decode(resume)]
-    return query
-
-
-def format_match(hit: dict, base: str, collection: str, expanded: bool = False):
-    src = hit["_source"]
-    res = {
-        "article_title": src.get("article_title"),
-        "normalized_article_title": src.get("normalized_article_title"),
-        "publication_date": src.get("publication_date")[:10]
-        if src.get("publication_date")
-        else None,
-        "indexed_date": src.get("indexed_date"),
-        "language": src.get("language"),
-        "full_langauge": src.get("full_language"),
-        "url": src.get("url"),
-        "normalized_url": src.get("normalized_url"),
-        "original_url": src.get("original_url"),
-        "canonical_domain": src.get("canonical_domain"),
-        "id": urls.unique_url_hash(src.get("url")),
-    }
-    if expanded:
-        res["text_content"] = src.get("text_content")
-        res["text_extraction"] = src.get("text_extraction")
-    return res
-
-
-def format_day_counts(bucket: list):
-    return {item["key_as_string"][:10]: item["doc_count"] for item in bucket}
-
-
-def format_counts(bucket: list):
-    return {item["key"]: item["doc_count"] for item in bucket}
 
 
 def proxy_base_url(req: Request):
@@ -451,34 +213,13 @@ def search_root(collection: Collection, req: Request):
     )
 
 
-def _search_overview(collection: Collection, q: str, req: Request):
-    res = ES.search(index=collection.name, body=cs_overview_query(q))  # type: ignore [call-arg]
-
-    if not res["hits"]["hits"]:
-        raise HTTPException(status_code=404, detail="No results found!")
-    total = res["hits"]["total"]["value"]
-    tldsum = sum(item["doc_count"] for item in res["aggregations"]["tld"]["buckets"])
-    base = proxy_base_url(req)
-    return {
-        "query": q,
-        "total": max(total, tldsum),
-        "topdomains": format_counts(res["aggregations"]["domain"]["buckets"]),
-        "toptlds": format_counts(res["aggregations"]["tld"]["buckets"]),
-        "toplangs": format_counts(res["aggregations"]["lang"]["buckets"]),
-        "dailycounts": format_day_counts(res["aggregations"]["daily"]["buckets"]),
-        "matches": [
-            format_match(h, base, collection.name) for h in res["hits"]["hits"]
-        ],
-    }
-
-
 @v1.get("/{collection}/search/overview", tags=["data"])
 @v1.head("/{collection}/search/overview", include_in_schema=False)
 def search_overview_via_query_params(collection: Collection, q: str, req: Request):
     """
     Report overview summary of the search result
     """
-    return _search_overview(collection, q, req)
+    return ES.search_overview(collection.name, q, req)
 
 
 @v1.post("/{collection}/search/overview", tags=["data"])
@@ -486,33 +227,7 @@ def search_overview_via_payload(collection: Collection, req: Request, payload: Q
     """
     Report summary of the search result
     """
-    return _search_overview(collection, payload.q, req)
-
-
-def _search_result(
-    collection: Collection,
-    q: str,
-    req: Request,
-    resp: Response,
-    resume: Union[str, None] = None,
-    expanded: bool = False,
-    sort_field: Optional[str] = None,
-    sort_order: Optional[str] = None,
-    page_size: Optional[int] = None,
-):
-    query = cs_paged_query(q, resume, expanded, sort_field, sort_order, page_size)
-    res = ES.search(index=collection.name, body=query)  # type: ignore [call-arg]
-    if not res["hits"]["hits"]:
-        raise HTTPException(status_code=404, detail="No results found!")
-    base = proxy_base_url(req)
-    qurl = f"{base}/{collection.name}/search/result?q={quote_plus(q)}"
-    if len(res["hits"]["hits"]) == (page_size or config["maxpage"]):
-        resume_key = encode(str(res["hits"]["hits"][-1]["sort"][0]))
-        resp.headers["x-resume-token"] = resume_key
-        
-    return [
-        format_match(h, base, collection.name, expanded) for h in res["hits"]["hits"]
-    ]
+    return ES.search_overview(collection.name, payload.q, req)
 
 
 @v1.get("/{collection}/search/result", tags=["data"])
@@ -531,8 +246,16 @@ def search_result_via_query_params(
     """
     Paged response of search result
     """
-    return _search_result(
-        collection, q, req, resp, resume, expanded, sort_field, sort_order, page_size
+    return ES.search_result(
+        collection.name,
+        q,
+        req,
+        resp,
+        resume,
+        expanded,
+        sort_field,
+        sort_order,
+        page_size,
     )
 
 
@@ -543,8 +266,8 @@ def search_result_via_payload(
     """
     Paged response of search result
     """
-    return _search_result(
-        collection,
+    return ES.search_result(
+        collection.name,
         payload.q,
         req,
         resp,
@@ -563,17 +286,7 @@ if config["debug"]:
         """
         Search using ES Query DSL as JSON payload
         """
-        return ES.search(index=collection.name, body=payload)  # type: ignore [call-arg]
-
-
-def _get_terms(collection: Collection, q: str, field: TermField, aggr: TermAggr):
-    res = ES.search(index=collection.name, body=cs_terms_query(q, field, aggr))  # type: ignore [call-arg]
-    if (
-        not res["hits"]["hits"]
-        or not res["aggregations"]["sample"]["topterms"]["buckets"]
-    ):
-        raise HTTPException(status_code=404, detail="No results found!")
-    return format_counts(res["aggregations"]["sample"]["topterms"]["buckets"])
+        return ES.ES.search(index=collection.name, body=payload)  # type: ignore [call-arg]
 
 
 @v1.get("/{collection}/terms", response_class=HTMLResponse, tags=["info"])
@@ -613,7 +326,7 @@ def get_terms_via_query_params(
     """
     Top terms with frequencies in matching articles
     """
-    return _get_terms(collection, q, field, aggr)
+    return ES.get_terms(collection.name, q, field.name, aggr.name)
 
 
 @v1.post("/{collection}/terms/{field}/{aggr}", tags=["data"])
@@ -626,7 +339,7 @@ def get_terms_via_payload(
     """
     Top terms with frequencies in matching articles
     """
-    return _get_terms(collection, payload.q, field, aggr)
+    return ES.get_terms(collection.name, payload.q, field.name, aggr.name)
 
 
 @v1.get("/{collection}/article/{id}", tags=["data"])
@@ -637,25 +350,8 @@ def get_article(
     """
     Fetch an individual article record by ID.
     """
-    source = {"includes": cs_basic_query(id, expanded=True)["_source"]}
-    query = {"match": {"_id": id}}
 
-    try:
-        res = ES.search(index=collection.name, source=source, query=query)
-        hits = res["hits"]["hits"]
-    except (TransportError, TypeError, KeyError) as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"An error occured when searching for article with ID {id}",
-        ) from e
-    if len(hits) > 0:
-        hit = hits[0]
-    else:
-        raise HTTPException(
-            status_code=404, detail=f"An article with ID {id} not found!"
-        )
-    base = proxy_base_url(req)
-    return format_match(hit, base, collection.name, True)  # type: ignore[arg-type]
+    return ES.get_article(collection.name, id, req)
 
 
 app.mount(f"/{ApiVersion.v1.name}", v1)

--- a/api.py
+++ b/api.py
@@ -227,7 +227,7 @@ def search_overview_via_query_params(collection: Collection, q: str, req: Reques
     """
     Report overview summary of the search result
     """
-    return ES.search_overview(collection.name, q, req)
+    return ES.search_overview(collection.name, q)
 
 
 @v1.post("/{collection}/search/overview", tags=["data"])
@@ -235,7 +235,7 @@ def search_overview_via_payload(collection: Collection, req: Request, payload: Q
     """
     Report summary of the search result
     """
-    return ES.search_overview(collection.name, payload.q, req)
+    return ES.search_overview(collection.name, payload.q)
 
 
 @v1.get("/{collection}/search/result", tags=["data"])
@@ -254,17 +254,18 @@ def search_result_via_query_params(
     """
     Paged response of search result
     """
-    return ES.search_result(
+
+    result, resume_key = ES.search_result(
         collection.name,
         q,
-        req,
-        resp,
         resume,
         expanded,
         sort_field,
         sort_order,
         page_size,
     )
+    resp.headers["x-resume-token"] = resume_key
+    return result
 
 
 @v1.post("/{collection}/search/result", tags=["data"])
@@ -274,17 +275,17 @@ def search_result_via_payload(
     """
     Paged response of search result
     """
-    return ES.search_result(
+    result, resume_key = ES.search_result(
         collection.name,
         payload.q,
-        req,
-        resp,
         payload.resume,
         payload.expanded,
         payload.sort_field,
         payload.sort_order,
         payload.page_size,
     )
+    resp.headers["x-resume-token"] = resume_key
+    return result
 
 
 if config.debug:
@@ -359,7 +360,7 @@ def get_article(
     Fetch an individual article record by ID.
     """
 
-    return ES.get_article(collection.name, id, req)
+    return ES.get_article(collection.name, id)
 
 
 app.mount(f"/{ApiVersion.v1.name}", v1)

--- a/api.py
+++ b/api.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 
-from queries import EsClientWrapper
+from client import EsClientWrapper
 from utils import (
     assert_elasticsearch_connection,
     env_to_dict,
@@ -27,6 +27,7 @@ from utils import (
     logger,
 )
 
+# Initialize our sentry integration
 if os.getenv("SENTRY_DSN"):
     sentry_sdk.init(
         dsn=os.getenv("SENTRY_DSN"),
@@ -62,7 +63,7 @@ ES = EsClientWrapper(config["eshosts"], **config["esopts"])
 
 Collection = Enum("Collection", [f"{kv}:{kv}".split(":")[:2] for kv in ES.get_allowed_collections()])  # type: ignore [misc]
 TermField = Enum("TermField", [f"{kv}:{kv}".split(":")[:2] for kv in env_to_list("TERMFIELDS")])  # type: ignore [misc]
-TermAggr = Enum("TermAggr", [f"{kv}:{kv}".split(":")[:2] for kv in env_to_list("TERMFIELDS")])  # type: ignore [misc]
+TermAggr = Enum("TermAggr", [f"{kv}:{kv}".split(":")[:2] for kv in env_to_list("TERMAGGRS")])  # type: ignore [misc]
 
 
 tags = [
@@ -121,10 +122,6 @@ class PagedQuery(Query):
     sort_field: Optional[str] = None
     sort_order: Optional[str] = None
     page_size: Optional[int] = None
-
-
-def proxy_base_url(req: Request):
-    return f'{str(os.getenv("PROXY_BASE", req.base_url)).rstrip("/")}/{req.scope.get("root_path").lstrip("/")}'  # type: ignore [union-attr]
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/deploy.sh
+++ b/deploy.sh
@@ -163,7 +163,7 @@ DOCKER_COMPOSE_FILE="docker-compose.yml"
 
 export ESOPTS='{"timeout": 60, "max_retries": 3}' # 'timeout' parameter is deprecated
 export TERMFIELDS="article_title,text_content"
-export TERMAGGRS="top,significant,rare"
+export TERMAGGRS="top"
 export ELASTICSEARCH_INDEX_NAME_PREFIX="mc_search"
 export API_PORT
 export API_REPLICAS

--- a/queries.py
+++ b/queries.py
@@ -1,0 +1,355 @@
+import base64
+import os
+import time
+from enum import Enum
+from typing import Dict, Optional, TypeAlias, Union
+
+import mcmetadata.urls as urls
+from elasticsearch import Elasticsearch
+from elasticsearch.exceptions import TransportError
+from fastapi import HTTPException, Request, Response
+
+from utils import assert_elasticsearch_connection, env_to_list, logger
+
+
+def decode(strng: str):
+    return base64.b64decode(strng.replace("~", "=").encode(), b"-_").decode()
+
+
+def encode(strng: str):
+    return base64.b64encode(strng.encode(), b"-_").decode().replace("=", "~")
+
+
+class QueryBuilder:
+
+    """
+    Utility Class to encapsulate the query construction logic for news-search-api
+
+    """
+
+    def __init__(self, query_text):
+        self.query_text = query_text
+        self.VALID_SORT_ORDERS = ["asc", "desc"]
+        self.VALID_SORT_FIELDS = ["publication_date", "indexed_date"]
+        self._source = [
+            "article_title",
+            "normalized_article_title",
+            "publication_date",
+            "indexed_date",
+            "language",
+            "full_language",
+            "canonical_domain",
+            "url",
+            "normalized_url",
+            "original_url",
+        ]
+        self._extended_source = [
+            "article_title",
+            "normalized_article_title",
+            "publication_date",
+            "indexed_date",
+            "language",
+            "full_language",
+            "canonical_domain",
+            "url",
+            "normalized_url",
+            "original_url",
+            "text_content",
+            "text_extraction",
+        ]
+
+    def _validate_sort_order(self, sort_order: Optional[str]):
+        if sort_order and sort_order not in self.VALID_SORT_ORDERS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid sort order (must be on of {', '.join(self.VALID_SORT_ORDERS)})",
+            )
+        return sort_order
+
+    def _validate_sort_field(self, sort_field: Optional[str]):
+        if sort_field and sort_field not in self.VALID_SORT_FIELDS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid sort field (must be on of {', '.join(self.VALID_SORT_FIELDS)})",
+            )
+        return sort_field
+
+    def _validate_page_size(self, page_size: Optional[int]):
+        if page_size and page_size < 1:
+            raise HTTPException(
+                status_code=400, detail="Invalid page size (must be greater than 0)"
+            )
+        return page_size
+
+    def basic_query(self, expanded: bool = False) -> Dict:
+        default: dict = {
+            "_source": self._extended_source if expanded else self._source,
+            "query": {
+                "query_string": {
+                    "default_field": "text_content",
+                    "default_operator": "AND",
+                    "query": self.query_text,
+                }
+            },
+        }
+        return default
+
+    def overview_query(self):
+        query = self.basic_query()
+        query.update(
+            {
+                "aggregations": {
+                    "daily": {
+                        "date_histogram": {
+                            "field": "publication_date",
+                            "calendar_interval": "day",
+                            "min_doc_count": 1,
+                        }
+                    },
+                    "lang": {"terms": {"field": "language.keyword", "size": 100}},
+                    "domain": {"terms": {"field": "canonical_domain", "size": 100}},
+                    "tld": {"terms": {"field": "tld", "size": 100}},
+                },
+                "track_total_hits": True,
+            }
+        )
+        return query
+
+    def terms_query(self, field):
+        resct = 200
+        aggr_map = {
+            "terms": {
+                "field": field.name,
+                "size": resct,
+                "min_doc_count": 10,
+                "shard_min_doc_count": 5,
+            }
+        }
+        query = self.basic_query()
+        query.update(
+            {
+                "track_total_hits": False,
+                "_source": False,
+                "aggregations": {
+                    "sample": {
+                        "sampler": {"shard_size": 500},
+                        "aggregations": {"topterms": aggr_map},
+                    }
+                },
+            }
+        )
+        return query
+
+    def paged_query(
+        self,
+        resume: Union[str, None],
+        expanded: bool,
+        sort_field=Optional[str],
+        sort_order=Optional[str],
+        page_size=Optional[int],
+    ) -> Dict:
+        query = self.basic_query(expanded)
+        final_sort_field = self._validate_sort_field(sort_field or "publication_date")
+        final_sort_order = self._validate_sort_order(sort_order or "desc")
+        query.update(
+            {
+                "size": self._validate_page_size(page_size or 1000),
+                "track_total_hits": False,
+                "sort": {
+                    final_sort_field: {
+                        "order": final_sort_order,
+                        "format": "basic_date_time_no_millis",
+                    }
+                },
+            }
+        )
+        if resume:
+            # important to use `search_after` instead of 'from' for memory reasons related to paging through more
+            # than 10k results
+            query["search_after"] = [decode(resume)]
+        return query
+
+    def article_query(self):
+        default: dict = {
+            "_source": self._extended_source,
+            "query": {"match": {"_id": self.query_text}},
+        }
+
+        return default
+
+
+class EsClientWrapper:
+    # A wrapper to actually make the calls to elasticsearch
+    def __init__(self, eshosts, **esopts):
+        self.ES = Elasticsearch(eshosts, **esopts)
+        self.maxpage = os.getenv("maxpage", 1000)
+        max_retries = 10
+        retries = 0
+
+        while not assert_elasticsearch_connection(self.ES):
+            retries += 1
+            if retries < max_retries:
+                time.sleep(5)
+                logger.info(
+                    f"Connection to elasticsearch failed {retries} times, retrying"
+                )
+            else:
+                raise RuntimeError(
+                    f"Elasticsearch connection failed {max_retries} times, giving up."
+                )
+
+        self.index_name_prefix = os.getenv("ELASTICSEARCH_INDEX_NAME_PREFIX", "")
+        logger.info("Initialized ES client wrapper")
+
+    def get_allowed_collections(self):
+        # Only expose indexes with the correct prefix, and add a wildcard as well.
+
+        all_indexes = [
+            index
+            for index in self.ES.indices.get(index="*")
+            if index.startswith(self.index_name_prefix)
+        ]
+        for aliases in self.ES.indices.get_alias().values():
+            # returns: {"index_name":{"aliases":{"alias_name":{"is_write_index":bool}}}}
+            for alias in aliases["aliases"].keys():
+                if alias not in all_indexes:
+                    all_indexes.append(alias)
+
+        all_indexes.append(f"{self.index_name_prefix}-*")
+
+        logger.info(f"Exposed indices: {all_indexes}")
+        return all_indexes
+
+    def format_match(
+        self, hit: dict, base: str, collection: str, expanded: bool = False
+    ):
+        src = hit["_source"]
+        res = {
+            "article_title": src.get("article_title"),
+            "normalized_article_title": src.get("normalized_article_title"),
+            "publication_date": src.get("publication_date")[:10]
+            if src.get("publication_date")
+            else None,
+            "indexed_date": src.get("indexed_date"),
+            "language": src.get("language"),
+            "full_langauge": src.get("full_language"),
+            "url": src.get("url"),
+            "normalized_url": src.get("normalized_url"),
+            "original_url": src.get("original_url"),
+            "canonical_domain": src.get("canonical_domain"),
+            "id": urls.unique_url_hash(src.get("url")),
+        }
+        if expanded:
+            res["text_content"] = src.get("text_content")
+            res["text_extraction"] = src.get("text_extraction")
+        return res
+
+    def format_day_counts(self, bucket: list):
+        return {item["key_as_string"][:10]: item["doc_count"] for item in bucket}
+
+    def format_counts(self, bucket: list):
+        return {item["key"]: item["doc_count"] for item in bucket}
+
+    def proxy_base_url(self, req: Request):
+        return f'{str(os.getenv("PROXY_BASE", req.base_url)).rstrip("/")}/{req.scope.get("root_path").lstrip("/")}'  # type: ignore [union-attr]
+
+    def search_overview(self, collection: str, q: str, req: Request):
+        """
+        Get overview statistics for a query
+        """
+        res = self.ES.search(index=collection, body=QueryBuilder(q).overview_query())  # type: ignore [call-arg]
+        if not res["hits"]["hits"]:
+            raise HTTPException(status_code=404, detail="No results found!")
+
+        total = res["hits"]["total"]["value"]
+        tldsum = sum(
+            item["doc_count"] for item in res["aggregations"]["tld"]["buckets"]
+        )
+        base = self.proxy_base_url(req)
+        return {
+            "query": q,
+            "total": max(total, tldsum),
+            "topdomains": self.format_counts(res["aggregations"]["domain"]["buckets"]),
+            "toptlds": self.format_counts(res["aggregations"]["tld"]["buckets"]),
+            "toplangs": self.format_counts(res["aggregations"]["lang"]["buckets"]),
+            "dailycounts": self.format_day_counts(
+                res["aggregations"]["daily"]["buckets"]
+            ),
+            "matches": [
+                self.format_match(h, base, collection) for h in res["hits"]["hits"]
+            ],
+        }
+
+    def search_result(
+        self,
+        collection: str,
+        q: str,
+        req: Request,
+        resp: Response,
+        resume: Union[str, None] = None,
+        expanded: bool = False,
+        sort_field: Optional[str] = None,
+        sort_order: Optional[str] = None,
+        page_size: Optional[int] = None,
+    ):
+        """
+        Get the search results for a query (including full text, if `expanded`)
+        """
+        query = QueryBuilder(q).paged_query(
+            resume, expanded, sort_field, sort_order, page_size
+        )
+        res = self.ES.search(index=collection, body=query)  # type: ignore [call-arg]
+        base = self.proxy_base_url(req)
+
+        if not res["hits"]["hits"]:
+            raise HTTPException(status_code=404, detail="No results found!")
+
+        if len(res["hits"]["hits"]) == (page_size or self.maxpage):
+            resume_key = encode(str(res["hits"]["hits"][-1]["sort"][0]))
+            resp.headers["x-resume-token"] = resume_key
+
+        return [
+            self.format_match(h, base, collection, expanded)
+            for h in res["hits"]["hits"]
+        ]
+
+    def get_terms(
+        self,
+        collection: str,
+        q: str,
+        field: str,
+        aggr: str,
+    ):
+        """
+        Get top terms associated with a query
+        """
+        res = self.ES.search(index=collection, body=QueryBuilder(q).terms_query(field))  # type: ignore [call-arg]
+        if (
+            not res["hits"]["hits"]
+            or not res["aggregations"]["sample"]["topterms"]["buckets"]
+        ):
+            raise HTTPException(status_code=404, detail="No results found!")
+        return self.format_counts(res["aggregations"]["sample"]["topterms"]["buckets"])
+
+    def get_article(self, collection: str, id: str, req):
+        """
+        Get an individual article by id.
+        """
+        try:
+            res = self.ES.search(
+                index=collection, body=QueryBuilder(id).article_query()
+            )
+            hits = res["hits"]["hits"]
+        except (TransportError, TypeError, KeyError) as e:
+            raise HTTPException(
+                status_code=500,
+                detail=f"An error occured when searching for article with ID {id}",
+            ) from e
+        if len(hits) > 0:
+            hit = hits[0]
+        else:
+            raise HTTPException(
+                status_code=404, detail=f"An article with ID {id} not found!"
+            )
+        base = self.proxy_base_url(req)
+        return self.format_match(hit, base, collection, True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ matplotlib==3.8.*
 mediacloud-metadata==0.11.*
 pandas==2.2.*
 pydantic==2.5.*
+pydantic_settings==2.*
 requests
 streamlit==1.30.*
 uvicorn[standard]

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-INDEX_NAME = "mediacloud_test"
+INDEX_NAME = "mc_search"
 ELASTICSEARCH_URL = "http://localhost:9200"
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 NUMBER_OF_TEST_STORIES = 5103

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -12,10 +12,12 @@ from api import ApiVersion, app
 # the `create_fixtures.py` script
 os.environ["INDEXES"] = INDEX_NAME
 os.environ["ESHOSTS"] = ELASTICSEARCH_URL
-os.environ["ELASTICSEARCH_INDEX_NAME_PREFIX"] = "mediacloud"
+os.environ["TERMFIELDS"] = "article_title,text_content"
+os.environ["TERMAGGRS"] = "top"
+os.environ["ELASTICSEARCH_INDEX_NAME_PREFIX"] = "mc_search"
 
 
-TIMEOUT = 30
+TIMEOUT = 60
 
 
 class ApiTest(TestCase):

--- a/test/create_fixtures.py
+++ b/test/create_fixtures.py
@@ -73,14 +73,15 @@ for idx in range(0, NUMBER_OF_TEST_STORIES):
     if (idx % 1000) != 0:
         fixture["publication_date"] = pub_date.isoformat()
     else:  # make sure some have no publication date, and mark them for easy searching
-        fixture["publication_date"] = None
+        fixture["publication_date"] = None  # type: ignore [assignment]
         fixture["article_title"] += " (no publication date)"
         fixture["text_content"] += " (no publication date)"
     fixture["normalized_article_title"] = titles.normalize_title(
         fixture["article_title"]
     )
-    random_time_on_day = (dt.datetime(pub_date.year, pub_date.month, pub_date.day) +
-                          dt.timedelta(minutes=randrange(1440)))
+    random_time_on_day = dt.datetime(
+        pub_date.year, pub_date.month, pub_date.day
+    ) + dt.timedelta(minutes=randrange(1440))
     fixture["indexed_date"] = random_time_on_day.isoformat()
     unique_hash = urls.unique_url_hash(fixture["url"])
     try:

--- a/utils.py
+++ b/utils.py
@@ -1,50 +1,9 @@
-import json
 import logging
-import os
-from enum import Enum
-from typing import TypeAlias
 
-import yaml
 from elasticsearch import Elasticsearch
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def load_config():
-    conf = os.getenv("CONFIG", "config.yml")
-    try:
-        return yaml.safe_load(open(conf, encoding="UTF-8"))
-    except OSError:
-        return {}
-
-
-def env_to_list(name: str):
-    return " ".join(os.getenv(name, "").split(",")).split()
-
-
-def env_to_dict(name: str):
-    return json.loads(os.getenv(name, "{}"))
-
-
-def list_to_enum(name: str, koptv: list):
-    # Just use StrEnum? py3.11 feature- let's attempt.
-    return Enum(name, [f"{kv}:{kv}".split(":")[:2] for kv in koptv])
-
-
-def env_to_float(name: str, defval: float | None) -> float | None:
-    """
-    fetch environment variable with name `name`
-    if not set, return defval
-    if set to empty string, return None
-    else interpret as floating point number
-    """
-    val = os.getenv(name)
-    if val is None:
-        return defval
-    if val == "":
-        return None
-    return float(val)
 
 
 def assert_elasticsearch_connection(es: Elasticsearch) -> bool:

--- a/utils.py
+++ b/utils.py
@@ -32,6 +32,21 @@ def list_to_enum(name: str, koptv: list):
     return Enum(name, [f"{kv}:{kv}".split(":")[:2] for kv in koptv])
 
 
+def env_to_float(name: str, defval: float | None) -> float | None:
+    """
+    fetch environment variable with name `name`
+    if not set, return defval
+    if set to empty string, return None
+    else interpret as floating point number
+    """
+    val = os.getenv(name)
+    if val is None:
+        return defval
+    if val == "":
+        return None
+    return float(val)
+
+
 def assert_elasticsearch_connection(es: Elasticsearch) -> bool:
     try:
         info = es.info()


### PR DESCRIPTION
Creates queries.py, which contains a QueryBuilder and an EsClientWrapper, separating concerns more explicitly. Also removes unused significant/rare term query logic. 
(Addressing #71)

Questions: 
- Are there enough modules here now that we want to package the code up in a subdirectory?
- Can we safely remove all of the config.yml logic? We're no longer using it, in favor of setting things via environment variables. 